### PR TITLE
Provide a valid subject when pushing event data.

### DIFF
--- a/coscale/lib/puppet/reports/coscale.rb
+++ b/coscale/lib/puppet/reports/coscale.rb
@@ -113,7 +113,7 @@ Puppet::Reports.register_report(:coscale) do
 
       data = {'message' => message,
               'timestamp' => timestamp,
-              'subject' => 'subject',
+              'subject' => 'a',
               }
 
       headers = {'HTTPAuthorization' => @cs_HTTPAuthorizationToken}


### PR DESCRIPTION
"subject" should either be the short of the server or group, or be "a" for application wide.
